### PR TITLE
hide documentation v2 navigation

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -36,8 +36,8 @@ website:
         menu:
           - text: OpenProblems v1
             href: https://github.com/openproblems-bio/openproblems/blob/main/CONTRIBUTING.md
-          - text: OpenProblems v2
-            href: documentation/index.qmd
+          # - text: OpenProblems v2
+          #   href: documentation/index.qmd
           - text: Bibliography
             href: bibliography.qmd
 

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -36,8 +36,8 @@ website:
         menu:
           - text: OpenProblems v1
             href: https://github.com/openproblems-bio/openproblems/blob/main/CONTRIBUTING.md
-          # - text: OpenProblems v2
-          #   href: documentation/index.qmd
+          - text: OpenProblems v2
+            href: https://github.com/openproblems-bio/openproblems-v2/blob/main/CONTRIBUTING.md
           - text: Bibliography
             href: bibliography.qmd
 


### PR DESCRIPTION
comment the OpenProblems v2 navbar item to hide it from website.
closes #74 